### PR TITLE
Update debbie.gemspec for Rails 5

### DIFF
--- a/debbie.gemspec
+++ b/debbie.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'hirb', '~> 0.7'
   gem.add_runtime_dependency 'coolline', '>= 0.4.2'
   gem.add_runtime_dependency 'awesome_print', '~> 1.2'
-  gem.add_runtime_dependency 'railties', '>= 3.0', '< 5.0'
+  gem.add_runtime_dependency 'railties', '>= 3.0', '< 5.2'
 end


### PR DESCRIPTION
Current error message:

```
Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    debbie (>= 1.0.2) was resolved to 1.0.2, which depends on
      railties (< 5.0, >= 3.0)

    rails (~> 5.0.0) was resolved to 5.0.0, which depends on
      railties (= 5.0.0)
```
