### PR TITLE
Jruby support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-Debbie 
+Debbie
 ==========
 Fully based on the amazing work of [@nixme][nixme] (Gopal Patel) on his gem [**Jazz Hands**][jazz_hands]
 
-__**We only removed some stuff that we're not using it**__
+__**We only removed some stuff that we're not using**__
+
+`pry-byebug` is not installed with gem, so Debbie works on all platforms, not only on MRI.
 
 ---
 
@@ -19,9 +21,13 @@ hard-working hands!
 * [**Pry Stack Explorer**][pry-stack_explorer] to navigate the call stack and
   frames.
 * [**Pry Remote**][pry-remote] to connect remotely to a Pry console.
-* [**Pry Byebug**][pry-byebug] Adds step, next, finish and continue commands and breakpoints to Pry using byebug.
 * [**Coolline**][coolline] & [**Coderay**][coderay] for syntax highlighting as
   you type. _Optional. MRI 1.9.3/2.0.0 only_
+
+And select one of debuggers:
+
+* [**Pry Byebug**][pry-byebug] Best choise for MRI rubies > 2.0.
+* [**Pry Nav**][pry-nav] Pry debugger for JRuby.
 
 ## To-Do
 
@@ -29,7 +35,7 @@ hard-working hands!
 
 
 ## Usage
-> #### IMPORTANT 
+> #### IMPORTANT
 > This version of **debbie** works on ruby version > 2.2, if you need to use it on a ruby 2.1+ or 2.0+ stick with the version 1.0.2
 
 Ruby 2.2+, Rails 3, 4 and 5. Add to your project Gemfile:
@@ -37,6 +43,9 @@ Ruby 2.2+, Rails 3, 4 and 5. Add to your project Gemfile:
 ```ruby
 group :development, :test do
   gem 'debbie'
+  # and one of debuggers
+  gem 'pry-byebug', platforms: [:mri]
+  gem 'pry-nav', platforms: [:java]
 end
 ```
 
@@ -105,3 +114,4 @@ file an [issue][issues]. [Project changelog][changelog].
 [changelog]:          https://github.com/goodpeople/debbie/blob/master/CHANGELOG.md
 [simple-log-time]:    http://www.pablocantero.com/blog/2014/08/17/quick-and-dirty-simple-ruby-profiler/
 [pry-byebug]:         https://github.com/deivid-rodriguez/pry-byebug
+[pry-nav]:            https://github.com/nixme/pry-nav

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'debbie'
+
+Debbie.setup
+Pry.start

--- a/debbie.gemspec
+++ b/debbie.gemspec
@@ -10,7 +10,10 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/goodpeople/debbie'
   gem.summary       = 'Exercise those fingers. Pry-based enhancements for the default Rails console.'
-  gem.description   = "Spending hours in the rails console? Spruce it up and show off those hard-working hands! Debbie replaces IRB with Pry, improves output through awesome_print, and has some other goodies up its sleeves."
+  gem.description   = 'Spending hours in the rails console? ' \
+                      'Spruce it up and show off those hard-working hands! ' \
+                      'Debbie replaces IRB with Pry, improves output through awesome_print, ' \
+                      'and has some other goodies up its sleeves.'
 
   gem.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(spec|bin)/}) }
@@ -19,12 +22,17 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '~> 2.2'
-  gem.add_runtime_dependency "pry", "~> 0.10"
-  gem.add_runtime_dependency "pry-doc", "~> 0.6"
+  gem.add_runtime_dependency 'pry', '~> 0.10'
+  gem.add_runtime_dependency 'pry-doc', '~> 0.6'
   gem.add_runtime_dependency 'pry-rails', '~> 0.3'
-  gem.add_runtime_dependency 'pry-byebug'
   gem.add_runtime_dependency 'hirb', '~> 0.7'
   gem.add_runtime_dependency 'coolline', '>= 0.4.2'
   gem.add_runtime_dependency 'awesome_print', '~> 1.2'
   gem.add_runtime_dependency 'railties', '>= 3.0'
+
+  if RUBY_PLATFORM == 'java'
+    gem.add_development_dependency 'pry-nav'
+  else
+    gem.add_development_dependency 'pry-byebug'
+  end
 end

--- a/debbie.gemspec
+++ b/debbie.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Exercise those fingers. Pry-based enhancements for the default Rails console.'
   gem.description   = "Spending hours in the rails console? Spruce it up and show off those hard-working hands! Debbie replaces IRB with Pry, improves output through awesome_print, and has some other goodies up its sleeves."
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
+  gem.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
+  gem.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(spec|bin)/}) }
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.require_paths = ['lib']
 

--- a/examples/debugger.rb
+++ b/examples/debugger.rb
@@ -1,0 +1,6 @@
+require 'bundler/setup'
+require 'debbie'
+# jruby has problems when debugger is called from main script, so we require one:
+require_relative './test_module'
+
+TestModule.bsearch((1..10).to_a, 1)

--- a/examples/test_module.rb
+++ b/examples/test_module.rb
@@ -1,0 +1,29 @@
+module SomeOther
+  def some_method
+  end
+end
+
+
+module TestModule
+  module_function
+
+  def bsearch(container, item)
+    return nil if item.nil?
+    low = 0
+    high = container.size - 1
+    while low <= high
+      # jruby may require one more `step`, just tap it it wice.
+      binding.pry
+      mid = (low + high) / 2
+      val = container[mid]
+      if val > item
+        high = mid - 1
+      elsif val < item
+        low = mid + 1
+      else
+        return val
+      end
+    end
+    nil
+  end
+end

--- a/lib/debbie/railtie.rb
+++ b/lib/debbie/railtie.rb
@@ -1,67 +1,9 @@
-require 'pry'
 require 'pry-rails'
-require 'awesome_print'
-require 'debbie/hirb_ext'
-
 
 module Debbie
   class Railtie < Rails::Railtie
     initializer 'debbie.initialize' do |app|
-      silence_warnings do
-        # We're managing the loading of plugins. So don't let pry autoload them.
-        Pry.config.should_load_plugins = false
-
-        # Use awesome_print for output, but keep pry's pager. If Hirb is
-        # enabled, try printing with it first.
-        Pry.config.print = proc do |output, value|
-          return if Debbie._hirb_output && Hirb::View.view_or_page_output(value)
-          pretty = value.ai(indent: 2)
-          Pry::Helpers::BaseHelpers.stagger_output("=> #{pretty}", output)
-        end
-
-        # Friendlier prompt - line number, app name, nesting levels look like
-        # directory paths.
-        #
-        # Heavy use of lazy lambdas so configuration (like Pry.color) can be
-        # changed later or even during console usage.
-        #
-        # Custom color helpers using hints \001 and \002 so that good readline
-        # libraries (GNU, rb-readline) correctly ignore color codes when
-        # calculating line length.
-
-        color = -> { Pry.color && Debbie.colored_prompt }
-        red  = ->(text) { color[] ? "\001\e[0;31m\002#{text}\001\e[0m\002" : text.to_s }
-        blue = ->(text) { color[] ? "\001\e[0;34m\002#{text}\001\e[0m\002" : text.to_s }
-        bold = ->(text) { color[] ? "\001\e[1m\002#{text}\001\e[0m\002"    : text.to_s }
-
-        separator = -> { red.(Debbie.prompt_separator) }
-        name = app.class.parent_name.underscore
-        colored_name = -> { blue.(name) }
-
-        line = ->(pry) { "[#{bold.(pry.input_array.size)}] " }
-        target_string = ->(object, level) do
-          level = 0 if level < 0
-          unless (string = Pry.view_clip(object)) == 'main'
-            "(#{'../' * level}#{string})"
-          else
-            ''
-          end
-        end
-
-        Pry.config.prompt = [
-          ->(object, level, pry) do      # Main prompt
-            "#{line.(pry)}#{colored_name.()}#{target_string.(object, level)} #{separator.()}  "
-          end,
-          ->(object, level, pry) do      # Wait prompt in multiline input
-            spaces = ' ' * (
-              "[#{pry.input_array.size}] ".size +  # Uncolored `line.(pry)`
-              name.size +
-              target_string.(object, level).size
-            )
-            "#{spaces} #{separator.()}  "
-          end
-        ]
-      end
+      silence_warnings { Debbie.setup(name: app.class.parent_name.underscore) }
     end
   end
 end


### PR DESCRIPTION
Hi!

WDYT about adding support for jruby? It seems that for now gem can not have platform-specific dependencies, so it's required to release separate gems. I've named it 'debbie-java'.

I've just got the idea to override rake task, so it'll be possible to release both gems with a single command on any ruby platform. I'll add it little bit later.

In this PR I've also moved all initialisation out from Railtie to Debbie module, and added `bin/console` to run and check the gem without right from its folder.

**UPD** I think the best approach is just remove pry-byebug from dependencies, and let people chose debugger. In this way single gem will fit all platforms.
